### PR TITLE
NTI-10253: Allow absolute paths for template spec.

### DIFF
--- a/src/nti/mailer/_default_template_mailer.py
+++ b/src/nti/mailer/_default_template_mailer.py
@@ -58,16 +58,6 @@ def _get_renderer_spec_and_package(base_template,
     if ':' not in base_template and '/' not in base_template:
         base_template = 'templates/' + base_template
 
-    # pyramid_mako < 1.0 does not properly accept a package argument
-    # and a relative template path; such a specification is
-    # considered to be relative to mako's search directory,
-    # which is not what we want. We could fix this with a special
-    # TemplateLookup object, but instead it's a quick
-    # hack to alter the names here.
-    # This should be fixed with 1.0a2, we could probably drop
-    if extension == '.mak' and ':' not in base_template:
-        base_template = package.__name__ + ':' + base_template
-
     return base_template + extension, package
 
 

--- a/src/nti/mailer/tests/templates/test_new_user_created.mak
+++ b/src/nti/mailer/tests/templates/test_new_user_created.mak
@@ -1,0 +1,19 @@
+Hi ${profile.realname}!
+
+Thank you for creating your new account and welcome to NextThought!
+
+Username: ${user.username}
+Log in at: ${request.application_url}
+
+NextThought offers interactive content and rich features to make
+learning both social and personal.
+
+Please verify your email address. Doing so will
+help us maintain the security of your account.
+To verify your email address, use the following link: ${href}
+
+Sincerely,
+NextThought
+
+If you feel this email was sent in error, or this account was created
+without your consent, you may email us at ${support_email}.

--- a/src/nti/mailer/tests/test_default_template_mailer.py
+++ b/src/nti/mailer/tests/test_default_template_mailer.py
@@ -154,6 +154,7 @@ class TestEmail(unittest.TestCase):
                                                                    'href': token_url,
                                                                    'support_email': 'support_email' },
                                                     package='nti.mailer',
+                                                    text_template_extension=".mak",
                                                     request=request)
                 assert_that(msg, is_(not_none()))
 
@@ -234,4 +235,31 @@ class TestEmail(unittest.TestCase):
                                                     request=request)
                 assert_that(msg, none())
 
+        @fudge.patch('nti.mailer._verp._brand_name')
+        def test_create_email_with_mako(self, brand_name):
+            brand_name.is_callable().returns(None)
 
+            class User(object):
+                username = 'the_user'
+
+            class Profile(object):
+                realname = u'Mickey Mouse'
+
+            user = User()
+            profile = Profile()
+            request = Request()
+            request.context = user
+
+            token_url = 'url_to_verify_email'
+            msg = create_simple_html_text_email('tests/templates/test_new_user_created',
+                                                subject='Hi there',
+                                                recipients=['jason.madden@nextthought.com'],
+                                                template_args={'user': user,
+                                                               'profile': profile,
+                                                               'context': user,
+                                                               'href': token_url,
+                                                               'support_email': 'support_email' },
+                                                package='nti.mailer',
+                                                text_template_extension=".mak",
+                                                request=request)
+            assert_that(msg, is_(not_none()))


### PR DESCRIPTION
Previously needed special handling for dealing with package arguments when using mako templates.  This is no longer the case and it was preventing us from using absolute paths.  Removed the unnecessary logic.