### PR TITLE
Add missing zc.displayname dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
         'pyramid_mailer',
         'six',
         'ZODB',
+        'zc.displayname',
         'zope.annotation',
         'zope.catalog',
         'zope.component',


### PR DESCRIPTION
#10 added a dependency on zc.displayname but didn't add it to setup.py. 