### PR TITLE
handle no IDisplayNameGenertor by using NextThought as the realname

### DIFF
--- a/src/nti/mailer/_verp.py
+++ b/src/nti/mailer/_verp.py
@@ -107,8 +107,9 @@ def _get_default_sender():
 
 
 def _brand_name(request):
-    return component.getMultiAdapter((getSite(), request),
-                                     IDisplayNameGenerator)()
+    dng = component.queryMultiAdapter((getSite(), request),
+                                      IDisplayNameGenerator)
+    return dng() if dng != None else None
 
 
 def _find_default_realname(request=None):

--- a/src/nti/mailer/tests/test_verp.py
+++ b/src/nti/mailer/tests/test_verp.py
@@ -134,6 +134,8 @@ class TestVerp(unittest.TestCase):
                 # be called
                 get_current_request.is_callable().returns(request).times_called(0)
 
+                # If we have a IDisplayNameGenerator registered for the current site
+                # we'll use that for the real name
                 displayname_adapter = _make_displayname_adapter("Brand XYZ")
                 with provide_adapter(displayname_adapter,
                                      required=(object, object),
@@ -161,6 +163,18 @@ class TestVerp(unittest.TestCase):
 
                     assert_that(name, is_('Brand XYZ'))
                     assert_that(email, is_('no-reply+foo.UGQXuA@nextthought.com'))
+
+                # But if we don't have an IDisplayNameGenerator, we default to NextThought
+                prin = self.email_addr_principal('foo', 'foo@bar.com')
+                addr = verp_from_recipients('no-reply@nextthought.com',
+                                            (prin,),
+                                            default_key='alpha.nextthought.com',
+                                            request=request)
+
+                name, email = parseaddr(addr)
+
+                assert_that(name, is_('NextThought'))
+                assert_that(email, is_('no-reply+foo.UGQXuA@nextthought.com'))
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
We have some applications that use this library but that don't have IDisplayNameGenerators setup. This makes the #10 backwards compatible for those applications.