### PR TITLE
NTI-10464: Avoid issues fetching request context while sending emails in spawned greenlets.

### DIFF
--- a/src/nti/mailer/_default_template_mailer.py
+++ b/src/nti/mailer/_default_template_mailer.py
@@ -175,7 +175,7 @@ def create_simple_html_text_email(base_template,
         the_context_name = 'nti_context' if extension == text_template_extension and text_template_extension != '.txt' else 'context'
         result = {}
         if request:
-            result[the_context_name] = request.context
+            result[the_context_name] = getattr(request, 'context', None)
         if template_args:
             result.update(template_args)
 


### PR DESCRIPTION
See also:
https://github.com/NextThought/nti.app.products.courseware_store/pull/9

Both of the places we ran into issues are effectively fetching their contexts from somewhere other than the request already.  The digest, which has no real view context, is setting up the `SiteTransactedBulkEmailProcessLoop` as both the view and the context of that view.  For the email sent around store purchase events, they mostly use the event that triggered the email (e.g.  `IPurchaseAttemptSuccessful` or `IStoreEnrollmentEvent`) as the context.  The gift purchase was an exception, and I modified that path to be consistent, should we end up using it in the future (see the PR linked above for that).