### PR TITLE
MailerWatcher can falsely skip filesystem notifications

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,10 @@
 [run]
 source = nti.mailer
+# Note that greenlet concurrency is only needed for
+# correctly measuring MailerWatcher (and even then right now
+# only in one test). However, greenlet concurrency isn't supported
+# on PyPy. We choose to disable coverage testing on GHA+PyPy for now,
+# because we have no PyPy specific code paths.
 concurrency = greenlet
 # New in 5.0; required for the GHA coveralls submission.
 relative_files = True

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 source = nti.mailer
+concurrency = greenlet
 # New in 5.0; required for the GHA coveralls submission.
 relative_files = True
 omit =

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.py ident

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
       run: |
         coverage run -m zope.testrunner --test-path=src  --auto-color --auto-progress
         coverage run -a -m sphinx -b doctest -d docs/_build/doctrees docs docs/_build/doctests
-        coverage report -i
+        coverage report -i --fail-under=95
     - name: Test Without Coverage
       if: startsWith(matrix.python-version, 'pypy')
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,8 +6,9 @@ env:
   PYTHONHASHSEED: 1042466059
   ZOPE_INTERFACE_STRICT_IRO: 1
   # The libuv loop has much better behaved stat
-  # watchers
-  GEVENT_LOOP: libuv
+  # watchers (they respond faster), though they tend
+  # to lead to crashes. This needs debugged in gevent.
+  #GEVENT_LOOP: libuv
   PYTHONDEVMODE: 1
   PYTHONUNBUFFERED: 1
   PYTHONFAULTHANDLER: 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,7 @@ env:
   GEVENT_LOOP: libuv
   PYTHONDEVMODE: 1
   PYTHONUNBUFFERED: 1
+  PYTHONFAULTHANDLER: 1
 
 
 jobs:
@@ -40,16 +41,17 @@ jobs:
         python -m pip install -U pip setuptools wheel
         python -m pip install -U coverage
         python -m pip install -U -e ".[test,docs]"
+        python -m pip install -q -U 'faulthandler; python_version == "2.7" and platform_python_implementation == "CPython"'
     - name: Test With Coverage
       if: matrix.python-version != 'pypy2' && matrix.python-version != 'pypy3'
       run: |
-        coverage run -m zope.testrunner --test-path=src  --auto-color -v
+        coverage run -m zope.testrunner --test-path=src  --auto-color -vvv
         coverage run -a -m sphinx -b doctest -d docs/_build/doctrees docs docs/_build/doctests
         coverage report -i --fail-under=95
     - name: Test Without Coverage
       if: startsWith(matrix.python-version, 'pypy')
       run: |
-        python -m zope.testrunner --test-path=src  --auto-color --auto-progress
+        python -m zope.testrunner --test-path=src  --auto-color -vvv
         python -m sphinx -b doctest -d docs/_build/doctrees docs docs/_build/doctests
     - name: Submit to Coveralls
       # This is a container action, which only runs on Linux.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,19 +36,19 @@ jobs:
         python -m pip install -U coverage
         python -m pip install -U -e ".[test,docs]"
     - name: Test With Coverage
-      if: ! startswith(matrix.python-version, 'pypy')
+      if: matrix.python-version != 'pypy2' && matrix.python-version != 'pypy3'
       run: |
         coverage run -m zope.testrunner --test-path=src  --auto-color --auto-progress
         coverage run -a -m sphinx -b doctest -d docs/_build/doctrees docs docs/_build/doctests
         coverage report -i
     - name: Test Without Coverage
-      if: startswith(matrix.python-version, 'pypy')
+      if: startsWith(matrix.python-version, 'pypy')
       run: |
         python -m zope.testrunner --test-path=src  --auto-color --auto-progress
         python -m sphinx -b doctest -d docs/_build/doctrees docs docs/_build/doctests
     - name: Submit to Coveralls
       # This is a container action, which only runs on Linux.
-      if: ! startswith(matrix.python-version, 'pypy')
+      if: matrix.python-version != 'pypy2' && matrix.python-version != 'pypy3'
       uses: AndreMiras/coveralls-python-action@develop
       with:
         parallel: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,13 +35,20 @@ jobs:
         python -m pip install -U pip setuptools wheel
         python -m pip install -U coverage
         python -m pip install -U -e ".[test,docs]"
-    - name: Test
+    - name: Test With Coverage
+      if: ! startswith(matrix.python-version, 'pypy')
       run: |
         coverage run -m zope.testrunner --test-path=src  --auto-color --auto-progress
         coverage run -a -m sphinx -b doctest -d docs/_build/doctrees docs docs/_build/doctests
         coverage report -i
+    - name: Test Without Coverage
+      if: startswith(matrix.python-version, 'pypy')
+      run: |
+        python -m zope.testrunner --test-path=src  --auto-color --auto-progress
+        python -m sphinx -b doctest -d docs/_build/doctrees docs docs/_build/doctests
     - name: Submit to Coveralls
       # This is a container action, which only runs on Linux.
+      if: ! startswith(matrix.python-version, 'pypy')
       uses: AndreMiras/coveralls-python-action@develop
       with:
         parallel: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,8 @@ env:
   # The libuv loop has much better behaved stat
   # watchers
   GEVENT_LOOP: libuv
+  PYTHONDEVMODE: 1
+  PYTHONUNBUFFERED: 1
 
 
 jobs:
@@ -41,7 +43,7 @@ jobs:
     - name: Test With Coverage
       if: matrix.python-version != 'pypy2' && matrix.python-version != 'pypy3'
       run: |
-        coverage run -m zope.testrunner --test-path=src  --auto-color --auto-progress
+        coverage run -m zope.testrunner --test-path=src  --auto-color -v
         coverage run -a -m sphinx -b doctest -d docs/_build/doctrees docs docs/_build/doctests
         coverage report -i --fail-under=95
     - name: Test Without Coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,9 @@ on: [push, pull_request]
 env:
   PYTHONHASHSEED: 1042466059
   ZOPE_INTERFACE_STRICT_IRO: 1
+  # The libuv loop has much better behaved stat
+  # watchers
+  GEVENT_LOOP: libuv
 
 
 jobs:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,8 +3,16 @@
 =========
 
 
-1.0.0 (unreleased)
+0.0.1 (unreleased)
 ==================
 
 - Add support for Python 3.6 through 3.9. 3.10 is expected when
   zodbpickle supports it.
+
+- Translate the *subject* argument given to the default
+  ``ITemplatedMailer`` implementation. See `issue 18
+  <https://github.com/NextThought/nti.mailer/issues/18>`_.
+
+- Deprecate the *message_factory* argument to
+  ``ITemplatedMailer.queue_simple_html_text_email``. If you use this
+  argument, please bring up your use-case in the issue tracker.

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ setup(
         'zope.component',
         'zope.container',
         'zope.dottedname',
+        'zope.i18n',
         'zope.interface',
         'zope.intid',
         'zope.location',

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ def _read(fname):
 
 setup(
     name='nti.mailer',
-    version="1.0.0.dev0",
+    version="0.0.1.dev0",
     author='Josh Zuech',
     author_email='josh.zuech@nextthought.com',
     description="NTI mailer",
@@ -42,6 +42,7 @@ setup(
         'Intended Audience :: Developers',
         'Natural Language :: English',
         'Operating System :: OS Independent',
+        'Development Status :: 3 - Alpha',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',

--- a/src/nti/mailer/_compat.py
+++ b/src/nti/mailer/_compat.py
@@ -15,7 +15,7 @@ except ImportError:  # pragma: no cover
 PY2 = sys.version_info[0] <= 2
 PY3 = sys.version_info[0] >= 3
 
-if PY2:
+if PY2: # pragma: no cover
     def is_nonstr_iter(v):
         return hasattr(v, '__iter__')
 else:

--- a/src/nti/mailer/_default_template_mailer.py
+++ b/src/nti/mailer/_default_template_mailer.py
@@ -205,8 +205,7 @@ def create_simple_html_text_email(base_template,
             "Mismatch between the explicit context and the template_args context. "
             "In the future this might be an error. Currently, one will be used for translation "
             "and one will be used in the template.",
-            FutureWarning,
-            stacklevel=3
+            stacklevel=2
         )
 
     cc = _as_recipient_list(cc)
@@ -245,15 +244,13 @@ def create_simple_html_text_email(base_template,
         # This should be fixed with 1.0a2
         the_context_name = 'nti_context' if extension == text_template_extension and text_template_extension != '.txt' else 'context'
         result = {}
-        if request:
-            result[the_context_name] = context
-        if template_args:
-            result.update(template_args)
+        result[the_context_name] = context
+        result.update(template_args)
 
         # Because the "correct" name for the context variable cannot be known
         # by the ``IMailerTemplateArgsUtility``, they should not attempt to
         # set it. Thus, we are always correct using our *context* value we
-        # discovered above.
+        # discovered above, except in the mismatch case.
         if the_context_name == 'nti_context' and 'context' in template_args:
             result[the_context_name] = template_args['context']
             del result['context']
@@ -350,7 +347,7 @@ def queue_simple_html_text_email(*args, **kwargs):
         kwargs['_level'] = 4
     message_factory = kwargs.pop('message_factory', create_simple_html_text_email)
     if message_factory is not create_simple_html_text_email:
-        warnings.warn("The message_factory argument is deprecated.", FutureWarning, stacklevel=2)
+        warnings.warn("The message_factory argument is deprecated.", stacklevel=2)
     message = message_factory(*args, **kwargs)
     # There are cases where this will be none (bounced email handling, missing
     # subject - error?). In at least the bounced email case, we want to avoid

--- a/src/nti/mailer/_default_template_mailer.py
+++ b/src/nti/mailer/_default_template_mailer.py
@@ -152,14 +152,20 @@ def create_simple_html_text_email(base_template,
     Create a :class:`pyramid_mailer.message.Message` by rendering
     the pair of templates to create a text and html part.
 
-    :keyword text_template_extension: The filename extension for the plain text template. Valid values
-            are ".txt" for Chameleon templates (this is the default and preferred version) and ".mak" for
-            Mako templates. Note that if you use Mako, the usual ``context`` argument is renamed to ``nti_context``,
-            as ``context`` is a reserved word in Mako.
-    :keyword package: If given, and the template is not an absolute
-            asset spec, then the template will be interpreted relative to this
-            package (and its templates/ subdirectory if no subdirectory is specified).
-            If no package is given, the package of the caller of this function is used.
+    :keyword str text_template_extension:
+        The filename extension for the plain text template. Valid
+        values are ".txt" for Chameleon templates (this is the default
+        and preferred version) and ".mak" for Mako templates. Note
+        that if you use Mako, the usual ``context`` argument is
+        renamed to ``nti_context``, as ``context`` is a reserved word
+        in Mako.
+    :keyword package:
+        If given, and the template is not an absolute asset spec, then
+        the template will be interpreted relative to this package (and
+        its templates/ subdirectory if no subdirectory is specified).
+        If no package is given, the package of the caller of this
+        function is used.
+
     .. versionchanged:: 0.0.1
         Now, if the *subject* is a :class:`zope.i18nmessageid.Message`, it will
         be translated.

--- a/src/nti/mailer/_verp.py
+++ b/src/nti/mailer/_verp.py
@@ -8,6 +8,10 @@ Implementation of the :class:`nti.mailer.interfaces.IVERP` protocol.
 
 from __future__ import print_function, absolute_import, division
 
+
+import zlib
+import struct
+
 from itsdangerous.exc import BadSignature
 
 from itsdangerous.signer import Signer
@@ -20,12 +24,15 @@ from zope.component.hooks import getSite
 
 from zope.security.interfaces import IPrincipal
 
+from six.moves import urllib_parse
+
 from nti.mailer._compat import parseaddr
 from nti.mailer._compat import formataddr
 
 from nti.mailer.interfaces import IVERP
 from nti.mailer.interfaces import IMailerPolicy
 from nti.mailer.interfaces import IEmailAddressable
+
 
 logger = __import__('logging').getLogger(__name__)
 
@@ -37,9 +44,6 @@ def _get_signer_secret(default_secret="$Id$"):
         result = policy.get_signer_secret()
     return result or default_secret
 
-
-import zlib
-import struct
 
 def _to_bytes(s, encoding='ascii'):
     # The default encoding of ascii is fine for our localized purpose of email, right?
@@ -109,7 +113,7 @@ def _get_default_sender():
 def _brand_name(request):
     dng = component.queryMultiAdapter((getSite(), request),
                                       IDisplayNameGenerator)
-    return dng() if dng != None else None
+    return dng() if dng is not None else None
 
 
 def _find_default_realname(request=None):
@@ -137,11 +141,10 @@ def _find_default_realname(request=None):
 def __make_signer(default_key, **kwargs):
     if not default_key:
         return _make_signer(**kwargs)
-    else:
-        return _make_signer(default_key=default_key, **kwargs)
+    return _make_signer(default_key=default_key, **kwargs)
 
 
-from six.moves import urllib_parse
+
 
 
 def _sign(signer, principal_ids):

--- a/src/nti/mailer/configure.zcml
+++ b/src/nti/mailer/configure.zcml
@@ -7,6 +7,7 @@
 	<include package="zope.security" file="meta.zcml" />
 	<include package="zope.component" />
 	<include package="zope.security" />
+	<include package="zope.i18n" />
 
 	<utility component="._verp" />
 

--- a/src/nti/mailer/interfaces.py
+++ b/src/nti/mailer/interfaces.py
@@ -31,24 +31,10 @@ __all__ = (
 
 # pylint:disable=inherit-non-class,no-self-argument,no-method-argument
 
-try:
-    from pyramid_mailer.interfaces import IMailer
-except ImportError: # pragma: no cover
-    class IMailer(interface.Interface):
-        pass
-
-try:
-    from repoze.sendmail.interfaces import IMailDelivery
-except ImportError: # pragma: no cover
-    class IMailDelivery(interface.Interface):
-        transaction_manager = interface.Attribute(u"The transaction manager to use.")
-
-        def send(fromaddr, toaddrs, message):
-            pass
-
-
+from pyramid_mailer.interfaces import IMailer
+from repoze.sendmail.interfaces import IMailDelivery
 from nti.schema.field import TextLine
-# pylint:disable=I0011,E0213
+
 
 logger = __import__('logging').getLogger(__name__)
 
@@ -108,7 +94,7 @@ class EmailAddressablePrincipal(object):
         for name in 'title', 'description':
             prin_val = getattr(prin, name, None)
             if prin_val is not None:
-                setattr(self, str(name), prin_val)
+                setattr(self, name, prin_val)
 
     def __str__(self):
         return str('Principal(%s/%s)' % (self.id, self.email))

--- a/src/nti/mailer/interfaces.py
+++ b/src/nti/mailer/interfaces.py
@@ -134,7 +134,8 @@ class ITemplatedMailer(interface.Interface):
                                      attachments=(),
                                      package=None,
                                      text_template_extension='.txt',
-                                     message_factory=None):
+                                     message_factory=None,
+                                     context=None):
         """
         Transactionally queues an email for sending. The email has both a
         plain text and an HTML version.
@@ -164,11 +165,22 @@ class ITemplatedMailer(interface.Interface):
                 passed to this function (minus this param) to create a
                 :class:`pyramid_mailer.message.Message` by rendering the pair
                 of templates to create a text and html part. Defaults to
-                :meth:`create_simple_html_text_email`.
+                :meth:`create_simple_html_text_email`. This argument is deprecated;
+                if you need it, please file an issue explaining your use-case.
 
 
         :return: The :class:`pyramid_mailer.message.Message` we sent, if we sent one,
                 otherwise None.
+
+        .. versionchanged:: 0.0.1
+           Now, if the *subject* is a :class:`zope.i18nmessageid.Message`, it will
+           be translated. Note that this only works if you do not override the
+           *message_factory* argument.
+        .. versionchanged:: 0.0.1
+           Added the *context* argument. If this argument is not supplied, the
+           value of ``request.context`` will be used. As a last resort, ``template_args['context']
+           will be used. (If both *context* or ``request.context`` and a template argument value
+           are given, they should all be the same object.)
         """
 
     def create_simple_html_text_email(base_template,
@@ -179,7 +191,8 @@ class ITemplatedMailer(interface.Interface):
                                       attachments=(),
                                       package=None,
                                       bcc=(),
-                                      text_template_extension='.txt'):
+                                      text_template_extension='.txt',
+                                      context=None):
         """
         The same arguments and return types as :meth:`queue_simple_html_text_email`,
         but without the actual transactional delivery.

--- a/src/nti/mailer/queue.py
+++ b/src/nti/mailer/queue.py
@@ -192,10 +192,14 @@ def _stat_watcher_modified(watcher):
     # XXX: This can fail (false negative) if modifications are coming
     # in faster than the resolution of the mtime, which depends on the
     # gevent loop in use, as well as the filesystem and possibly
-    # the configuration.
+    # the configuration. This is easily observed on GitHub Actions
+    # with both watchers; our writing process has to sleep to allow
+    # the modification times to appear to change.
     # XXX: Moreover, the very act of processing the queue will probably cause
     # the watcher to fire. We should probably stop the watcher while
     # processing the queue.
+    print("Prev time", _stat_modified_time(watcher.prev))
+    print("Attr time", _stat_modified_time(watcher.attr))
     return _stat_modified_time(watcher.prev) != _stat_modified_time(watcher.attr)
 
 

--- a/src/nti/mailer/queue.py
+++ b/src/nti/mailer/queue.py
@@ -189,6 +189,10 @@ def _stat_watcher_modified(watcher):
     Inspects the stat watcher to see if the modified time
     has changed between the current attrs and the prev attrs
     """
+    # XXX: This can fail (false negative) if modifications are coming
+    # in faster than the resolution of the mtime, which depends on the
+    # gevent loop in use, as well as the filesystem and possibly
+    # the configuration.
     return _stat_modified_time(watcher.prev) != _stat_modified_time(watcher.attr)
 
 

--- a/src/nti/mailer/tests/templates/__init__.py
+++ b/src/nti/mailer/tests/templates/__init__.py
@@ -1,10 +1,3 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-"""
-.. $Id$
-"""
-
-from __future__ import print_function, absolute_import, division
-__docformat__ = "restructuredtext en"
-
-logger = __import__('logging').getLogger(__name__)
+# Make this directory a package.

--- a/src/nti/mailer/tests/test_default_template_mailer.py
+++ b/src/nti/mailer/tests/test_default_template_mailer.py
@@ -364,9 +364,13 @@ class TestEmail(unittest.TestCase):
             warnings.simplefilter('always')
             self._create_simple_email(Request(), context=self)
 
-
-        self.assertEqual(len(warns), 1)
-        self.assertIn('Mismatch between the explicit', str(warns[0].message))
+        if str is not bytes:
+            # There's a bug in the 'always' simple filter on Python 2:
+            # It doesn't properly clear the stacklevel cache,
+            # so if we've emitted this warning by calling self._create_simple_email
+            # before, we don't catch that warning.
+            self.assertEqual(len(warns), 1)
+            self.assertIn('Mismatch between the explicit', str(warns[0].message))
 
 class _User(object):
     def __init__(self, username):

--- a/src/nti/mailer/tests/test_default_template_mailer.py
+++ b/src/nti/mailer/tests/test_default_template_mailer.py
@@ -5,8 +5,10 @@ from __future__ import print_function, absolute_import, division
 
 # disable: accessing protected members, too many methods
 # pylint: disable=W0212,R0904
+import unittest
+
 import fudge
-from nti.mailer._compat import parseaddr
+
 
 from hamcrest import is_
 from hamcrest import none
@@ -26,7 +28,6 @@ from pyramid_mailer.mailer import DummyMailer as _DummyMailer
 
 from repoze.sendmail.interfaces import IMailDelivery
 
-import unittest
 
 from zope import component
 
@@ -38,6 +39,7 @@ from zope.security.interfaces import IPrincipal
 
 from nti.app.pyramid_zope import z3c_zpt
 
+from nti.mailer._compat import parseaddr
 from nti.mailer._default_template_mailer import _pyramid_message_to_message
 from nti.mailer._default_template_mailer import create_simple_html_text_email
 
@@ -52,9 +54,6 @@ class ITestMailDelivery(IMailer, IMailDelivery):
 class TestMailDelivery(_DummyMailer):
 
     default_sender = 'no-reply@nextthought.com'
-
-    def __init__(self):
-        super(TestMailDelivery, self).__init__()
 
     def send(self, fromaddr, toaddr, message):
         __traceback_info__ = fromaddr, toaddr
@@ -102,193 +101,197 @@ class PyramidMailerLayer(object):
 @interface.implementer(IPrincipalEmailValidation)
 class TestEmailAddressablePrincipal(EmailAddressablePrincipal):
 
-        def __init__(self, user, is_valid=True, *args, **kwargs):
-                super(TestEmailAddressablePrincipal, self).__init__(user, *args, **kwargs)
-                self.is_valid = is_valid
+    def __init__(self, user, is_valid=True, *args, **kwargs):
+        super(TestEmailAddressablePrincipal, self).__init__(user, *args, **kwargs)
+        self.is_valid = is_valid
 
-        def is_valid_email(self):
-                return self.is_valid
+    def is_valid_email(self):
+        return self.is_valid
 
 
 @interface.implementer(IBrowserRequest)
 class Request(object):
-        context = None
-        response = None
-        application_url = 'foo'
+    context = None
+    response = None
+    application_url = 'foo'
 
-        def __init__(self):
-                self.annotations = {}
+    def __init__(self):
+        self.annotations = {}
 
-        def get(self, key, default=None):
-                return default
+    def get(self, key, default=None):
+        return default
 
 
 class TestEmail(unittest.TestCase):
 
-        layer = PyramidMailerLayer
+    layer = PyramidMailerLayer
 
-        @fudge.patch('nti.mailer._verp._brand_name')
-        def test_create_mail_message_with_non_ascii_name_and_string_bcc(self, brand_name):
-                brand_name.is_callable().returns(None)
+    @fudge.patch('nti.mailer._verp._brand_name')
+    def test_create_mail_message_with_non_ascii_name_and_string_bcc(self, brand_name):
+        brand_name.is_callable().returns(None)
 
-                class User(object):
-                        username = 'the_user'
+        class User(object):
+            username = 'the_user'
 
-                class Profile(object):
-                        # Note the umlaut e
-                        realname = u'Suzë Schwartz'
+        class Profile(object):
+            # Note the umlaut e
+            realname = u'Suzë Schwartz'
 
-                user = User()
-                profile = Profile()
-                request = Request()
-                request.context = user
+        user = User()
+        profile = Profile()
+        request = Request()
+        request.context = user
 
-                token_url = 'url_to_verify_email'
-                msg = create_simple_html_text_email('tests/templates/test_new_user_created',
-                                                    subject='Hi there',
-                                                    recipients=['jason.madden@nextthought.com'],
-                                                    bcc='foo@bar.com',
-                                                    template_args={'user': user,
-                                                                   'profile': profile,
-                                                                   'context': user,
-                                                                   'href': token_url,
-                                                                   'support_email': 'support_email' },
-                                                    package='nti.mailer',
-                                                    text_template_extension=".mak",
-                                                    request=request)
-                assert_that(msg, is_(not_none()))
+        token_url = 'url_to_verify_email'
+        msg = create_simple_html_text_email('tests/templates/test_new_user_created',
+                            subject='Hi there',
+                            recipients=['jason.madden@nextthought.com'],
+                            bcc='foo@bar.com',
+                            template_args={'user': user,
+                                           'profile': profile,
+                                           'context': user,
+                                           'href': token_url,
+                                           'support_email': 'support_email' },
+                            package='nti.mailer',
+                            text_template_extension=".mak",
+                            request=request)
+        assert_that(msg, is_(not_none()))
 
-                base_msg = _pyramid_message_to_message(msg, ['jason.madden@nextthought.com'], None)
+        base_msg = _pyramid_message_to_message(msg, ['jason.madden@nextthought.com'], None)
 
-                base_msg_string = str(base_msg)
-                # quoted-prinatble encoding of iso-8859-1 value of umlaut-e
-                assert_that(base_msg_string, contains_string('Hi=20Suz=EB=20Schwartz'))
+        base_msg_string = str(base_msg)
+        # quoted-prinatble encoding of iso-8859-1 value of umlaut-e
+        assert_that(base_msg_string, contains_string('Hi=20Suz=EB=20Schwartz'))
 
-                # Because we can't get to IPrincial, no VERP info
-                name, email = parseaddr(msg.sender)
-                assert_that(name, is_('NextThought'))
-                assert_that(email, is_('no-reply@nextthought.com'))
+        # Because we can't get to IPrincial, no VERP info
+        name, email = parseaddr(msg.sender)
+        assert_that(name, is_('NextThought'))
+        assert_that(email, is_('no-reply@nextthought.com'))
 
-                #
-                assert_that(msg, has_property('bcc', ['foo@bar.com']))
+        #
+        assert_that(msg, has_property('bcc', ['foo@bar.com']))
 
-        @fudge.patch('nti.mailer._verp._brand_name')
-        def test_create_email_with_verp(self, brand_name):
-                brand_name.is_callable().returns(None)
+    @fudge.patch('nti.mailer._verp._brand_name')
+    def test_create_email_with_verp(self, brand_name):
+        brand_name.is_callable().returns(None)
 
-                @interface.implementer(IPrincipal, IEmailAddressable)
-                class User(object):
-                        username = 'the_user'
-                        id = 'the_user'
-                        email = 'thomas.stockdale@nextthought.com'  # this address encodes badly to simple base64
+        @interface.implementer(IPrincipal, IEmailAddressable)
+        class User(object):
+            username = 'the_user'
+            id = 'the_user'
+            # this address encodes badly to simple base64
+            # XXX: What?
+            email = 'thomas.stockdale@nextthought.com'
 
-                class Profile(object):
-                        realname = u'Suzë Schwartz'
+        class Profile(object):
+            realname = u'Suzë Schwartz'
 
-                user = User()
-                profile = Profile()
-                request = Request()
-                request.context = user
+        user = User()
+        profile = Profile()
+        request = Request()
+        request.context = user
 
-                token_url = 'url_to_verify_email'
-                msg = create_simple_html_text_email('tests/templates/test_new_user_created',
-                                                    subject='Hi there',
-                                                    recipients=[TestEmailAddressablePrincipal(user, is_valid=True)],
-                                                    template_args={'user': user,
-                                                                   'profile': profile,
-                                                                   'context': user,
-                                                                   'href': token_url,
-                                                                   'support_email': 'support_email' },
-                                                    package='nti.mailer',
-                                                    request=request)
-                assert_that(msg, is_(not_none()))
-                # import pyramid_mailer
-                # from pyramid_mailer.interfaces import IMailer
-                # from zope import component
-                # mailer = pyramid_mailer.Mailer.from_settings( {'mail.queue_path': '/tmp/ds_maildir', 'mail.default_sender': 'no-reply@nextthought.com' } )
-                # component.provideUtility( mailer, IMailer )
-                # component.provideUtility(mailer.queue_delivery)
-                # from .._default_template_mailer import _send_mail
-                # _send_mail(msg, [user], None)
-                # import transaction
-                # transaction.commit()
+        token_url = 'url_to_verify_email'
+        msg = create_simple_html_text_email('tests/templates/test_new_user_created',
+                            subject='Hi there',
+                            recipients=[TestEmailAddressablePrincipal(user, is_valid=True)],
+                            template_args={'user': user,
+                                           'profile': profile,
+                                           'context': user,
+                                           'href': token_url,
+                                           'support_email': 'support_email' },
+                            package='nti.mailer',
+                            request=request)
+        assert_that(msg, is_(not_none()))
+        # import pyramid_mailer
+        # from pyramid_mailer.interfaces import IMailer
+        # from zope import component
+        # mailer = pyramid_mailer.Mailer.from_settings(
+        #    {'mail.queue_path': '/tmp/ds_maildir', 'mail.default_sender': 'no-reply@nextthought.com'
+        #  } )
+        # component.provideUtility( mailer, IMailer )
+        # component.provideUtility(mailer.queue_delivery)
+        # from .._default_template_mailer import _send_mail
+        # _send_mail(msg, [user], None)
+        # import transaction
+        # transaction.commit()
 
-                _pyramid_message_to_message(msg, [user], None)
+        _pyramid_message_to_message(msg, [user], None)
 
-                # we can get to IPrincipal, so we have VERP
-                # The first part will be predictable, the rest won't
-                name, email = parseaddr(msg.sender)
-                assert_that(name, is_('NextThought'))
-                assert_that(email, contains_string('no-reply+'))
+        # we can get to IPrincipal, so we have VERP
+        # The first part will be predictable, the rest won't
+        name, email = parseaddr(msg.sender)
+        assert_that(name, is_('NextThought'))
+        assert_that(email, contains_string('no-reply+'))
 
-                # Test invalid
-                invalid_user = TestEmailAddressablePrincipal(user, is_valid=False)
-                msg = create_simple_html_text_email('tests/templates/test_new_user_created',
-                                                    subject='Hi there',
-                                                    recipients=[invalid_user],
-                                                    template_args={'user': user,
-                                                                   'profile': profile,
-                                                                   'context': user,
-                                                                   'href': token_url,
-                                                                   'support_email': 'support_email' },
-                                                    package='nti.mailer',
-                                                    request=request)
-                assert_that(msg, none())
+        # Test invalid
+        invalid_user = TestEmailAddressablePrincipal(user, is_valid=False)
+        msg = create_simple_html_text_email('tests/templates/test_new_user_created',
+                            subject='Hi there',
+                            recipients=[invalid_user],
+                            template_args={'user': user,
+                                           'profile': profile,
+                                           'context': user,
+                                           'href': token_url,
+                                           'support_email': 'support_email' },
+                            package='nti.mailer',
+                            request=request)
+        assert_that(msg, none())
 
-        @fudge.patch('nti.mailer._verp._brand_name')
-        def test_create_email_with_mako(self, brand_name):
-            brand_name.is_callable().returns(None)
+    @fudge.patch('nti.mailer._verp._brand_name')
+    def test_create_email_with_mako(self, brand_name):
+        brand_name.is_callable().returns(None)
 
-            user = _User('the_user')
-            request = Request()
-            request.context = user
+        user = _User('the_user')
+        request = Request()
+        request.context = user
 
-            msg = self._create_simple_email(request,
-                                            text_template_extension=".mak")
-            assert_that(msg, is_(not_none()))
+        msg = self._create_simple_email(request,
+                                        text_template_extension=".mak")
+        assert_that(msg, is_(not_none()))
 
-        @fudge.patch('nti.mailer._verp._brand_name')
-        def test_create_email_no_request_context(self, brand_name):
-            brand_name.is_callable().returns(None)
+    @fudge.patch('nti.mailer._verp._brand_name')
+    def test_create_email_no_request_context(self, brand_name):
+        brand_name.is_callable().returns(None)
 
-            @interface.implementer(IBrowserRequest)
-            class Request(object):
-                response = None
-                application_url = 'foo'
+        @interface.implementer(IBrowserRequest)
+        class Request(object):
+            response = None
+            application_url = 'foo'
 
-                def __init__(self):
-                    self.annotations = {}
+            def __init__(self):
+                self.annotations = {}
 
-                def get(self, key, default=None):
-                    return default
+            def get(self, key, default=None):
+                return default
 
-            request = Request()
-            msg = self._create_simple_email(request,
-                                            text_template_extension=".mak")
-            assert_that(msg, is_(not_none()))
+        request = Request()
+        msg = self._create_simple_email(request,
+                                        text_template_extension=".mak")
+        assert_that(msg, is_(not_none()))
 
-        def _create_simple_email(self,
-                                 request,
-                                 user=None,
-                                 profile=None,
-                                 text_template_extension=".txt"):
+    def _create_simple_email(self,
+                 request,
+                 user=None,
+                 profile=None,
+                 text_template_extension=".txt"):
 
-            user = user or _User('the_user')
-            profile = profile or _Profile(u'Mickey Mouse')
+        user = user or _User('the_user')
+        profile = profile or _Profile(u'Mickey Mouse')
 
-            token_url = 'url_to_verify_email'
-            msg = create_simple_html_text_email('tests/templates/test_new_user_created',
-                                                subject='Hi there',
-                                                recipients=['jason.madden@nextthought.com'],
-                                                template_args={'user': user,
-                                                               'profile': profile,
-                                                               'context': user,
-                                                               'href': token_url,
-                                                               'support_email': 'support_email'},
-                                                package='nti.mailer',
-                                                text_template_extension=text_template_extension,
-                                                request=request)
-            return msg
+        token_url = 'url_to_verify_email'
+        msg = create_simple_html_text_email('tests/templates/test_new_user_created',
+                        subject='Hi there',
+                        recipients=['jason.madden@nextthought.com'],
+                        template_args={'user': user,
+                                       'profile': profile,
+                                       'context': user,
+                                       'href': token_url,
+                                       'support_email': 'support_email'},
+                        package='nti.mailer',
+                        text_template_extension=text_template_extension,
+                        request=request)
+        return msg
 
 
 class _User(object):

--- a/src/nti/mailer/tests/test_default_template_mailer.py
+++ b/src/nti/mailer/tests/test_default_template_mailer.py
@@ -55,18 +55,7 @@ class ITestMailDelivery(IMailer, IMailDelivery):
     pass
 
 class TestMailDelivery(_DummyMailer):
-
     default_sender = 'no-reply@nextthought.com'
-
-    def send(self, fromaddr, toaddr, message):
-        __traceback_info__ = fromaddr, toaddr
-        self.queue.append(message)
-        # compat with pyramid_mailer messages
-        message.subject = message.get('Subject')
-        payload = message.get_payload()
-        message.body = payload[0].get_payload()
-        if len(payload) > 1:
-            message.html = payload[1].get_payload()
 
 
 @interface.implementer(IBrowserRequest)
@@ -78,8 +67,6 @@ class Request(object):
         self.annotations = {}
         self.context = None
 
-    def get(self, key, default=None):
-        return default
 
 @interface.implementer(IUserPreferredLanguages)
 class TestPreferredLanguages(object):

--- a/src/nti/mailer/tests/test_interfaces.py
+++ b/src/nti/mailer/tests/test_interfaces.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for interfaces.py.
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+# disable: accessing protected members, too many methods
+# pylint: disable=W0212,R0904
+
+import unittest
+
+class AbstractPrincipal(object):
+    id = 'id'
+    email = 'sjohnson@nextthought.com'
+
+    def __conform__(self, iface):
+        return self
+
+
+class TestEmailAddressablePrincipal(unittest.TestCase):
+
+    def _makeOne(self, context):
+        from nti.mailer.interfaces import EmailAddressablePrincipal
+        return EmailAddressablePrincipal(context)
+
+    def test_copies_title(self):
+        class Context(AbstractPrincipal):
+            id = 'id'
+            title = 'MyTitle'
+
+        prin = self._makeOne(Context())
+        self.assertIs(prin.id, Context.id)
+        self.assertIs(prin.email, Context.email)
+        self.assertIs(prin.title, Context.title)
+        self.assertIsNone(prin.description)
+
+    def test_copies_description(self):
+        class Context(AbstractPrincipal):
+            id = 'id'
+            description = 'MyDesc'
+
+        prin = self._makeOne(Context())
+        self.assertIs(prin.id, Context.id)
+        self.assertIs(prin.email, Context.email)
+        self.assertIs(prin.description, Context.description)
+        self.assertIsNone(prin.title)
+
+    def test_str_repr(self):
+        prin = self._makeOne(AbstractPrincipal())
+        expected = 'Principal(id/sjohnson@nextthought.com)'
+        self.assertEqual(str(prin), expected)
+        self.assertEqual(repr(prin), expected)

--- a/src/nti/mailer/tests/test_queue.py
+++ b/src/nti/mailer/tests/test_queue.py
@@ -192,8 +192,10 @@ class TestMailerWatcher(TestLoopingMailerProcess):
             self._queue_two_messages()
             # Sleep (blocking) in case our stat watcher has
             # very poor mtime resolution; we don't want a false
-            # negative in our detection.
-            time.sleep(0.5)
+            # negative in our detection. For libuv watchers,
+            # 0.5 seems to be enough. But for libev watchers on GHA,
+            # we need a full second.
+            time.sleep(1.0)
 
         gevent.spawn(q)
 

--- a/src/nti/mailer/tests/test_queue.py
+++ b/src/nti/mailer/tests/test_queue.py
@@ -168,8 +168,16 @@ class TestMailerWatcher(TestLoopingMailerProcess):
 
     def test_deliver_messages_come_while_waiting(self):
         import gevent
+        import time
         # Next time we yield to the hub, this will get called.
-        gevent.spawn(self._queue_two_messages)
+        def q():
+            self._queue_two_messages()
+            # Sleep (blocking) in case our stat watcher has
+            # very poor mtime resolution; we don't want a false
+            # negative in our detection.
+            time.sleep(0.5)
+
+        gevent.spawn(q)
 
         # Some systems are very slow to detect changes. Notably,
         # libev on Darwin (macOS 10.15.7 on APFS) can take several

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ basepython =
 commands =
     coverage run -m zope.testrunner --test-path=src []
     coverage html
-    coverage report --fail-under=94
+    coverage report --fail-under=95
 deps =
     coverage
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ basepython =
 commands =
     coverage run -m zope.testrunner --test-path=src []
     coverage html
-    coverage report --fail-under=84
+    coverage report --fail-under=92
 deps =
     coverage
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ basepython =
 commands =
     coverage run -m zope.testrunner --test-path=src []
     coverage html
-    coverage report --fail-under=92
+    coverage report --fail-under=94
 deps =
     coverage
 


### PR DESCRIPTION
Because it tries to compare modification times of the directories, seeing if the "after" modification time has changed from the "before" time. But the resolution of those modification times is system dependent; it's common for the resolution to be 1 second or worse. So it's possible for two distinct `stat()` calls to return the same modification time, even if the kernel has reported the directory to have changed and new files have been written. In that case, we miss the notification.